### PR TITLE
Remove Ukraine 868MHz region code

### DIFF
--- a/standards/audits/data/settings-validation-apple.md
+++ b/standards/audits/data/settings-validation-apple.md
@@ -42,7 +42,7 @@ Protobuf message: `Config.LoRaConfig`
 
 | Field | UI Control | Constraint / Validation |
 |---|---|---|
-| `region` | Picker (enum) | Values from `RegionCode` enum (unset, US, EU_433, EU_868, CN, JP, ANZ, KR, TW, RU, IN, NZ_865, TH, LORA_24, UA_433, UA_868, MY_433, MY_919, SG_923) |
+| `region` | Picker (enum) | Values from `RegionCode` enum (unset, US, EU_433, EU_868, CN, JP, ANZ, KR, TW, RU, IN, NZ_865, TH, LORA_24, UA_433, MY_433, MY_919, SG_923) |
 | `usePreset` | Toggle | Boolean |
 | `modemPreset` | Picker (enum) | Values from `ModemPresets` enum; disabled when `usePreset` is false |
 | `hopLimit` | Picker (`ForEach 0..<8`) | Integer **0–7** inclusive. Proto: *"Maximum number of hops. This can't be greater than 7."* |


### PR DESCRIPTION
Ukrainian legislation[1] was harmonised with the EU's, and UA_868 is now obsolete as it is identical to the EU_868, so it was removed from the firmware.[2]

[1] http://zakon.rada.gov.ua/laws/show/262-2026-%D0%BF
[2] meshtastic/firmware#10994