### PR TITLE
docs(events): define signed event firmware OTA contract

### DIFF
--- a/.github/features/firmware-edition-event-behavior.md
+++ b/.github/features/firmware-edition-event-behavior.md
@@ -75,6 +75,103 @@ The manifest is first-party but **remote**, and it drives rendered text, opened 
 - **`fonts` are family-name identifiers, not URLs.** Resolve them only against the platform's own font provider. Never treat the value as a fetchable location.
 - **Colors are `#RRGGBB`.** Parse strictly and drop malformed entries rather than substituting a default that misrepresents the brand.
 
+### Executable firmware is authorized separately
+
+The display manifest does not authorize installation. In particular,
+`firmware.zipUrl` is informational and must never be promoted directly into an
+in-app OTA action. A client that offers event firmware OTA fetches a separately
+signed contract for the selected edition:
+
+```text
+GET https://api.meshtastic.org/resource/eventFirmware/{EDITION}/ota
+```
+
+Unknown editions return `404`. If the API signing key is unavailable, the
+endpoint fails closed with `503`; it must not return an unsigned contract.
+
+The response is an Ed25519 envelope. `payload` is the exact UTF-8 JSON bytes,
+base64 encoded, that were signed:
+
+```jsonc
+{
+  "keyId": "event-release-2026",
+  "payload": "<base64 contract JSON>",
+  "signature": "<base64 Ed25519 signature over decoded payload bytes>"
+}
+```
+
+Clients ship the trusted public key keyed by `keyId`. A key delivered by this
+endpoint, the display manifest, or an artifact host is not a trust root.
+Unknown keys, malformed base64, invalid signatures, expired contracts, and
+unsupported schema versions make in-app installation unavailable.
+
+The schema-1 contract is scoped to one event release:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "releaseId": "defcon34-2.8.0.b00d76f",
+  "edition": "DEFCON",
+  "version": "2.8.0.b00d76f",
+  "issuedAt": "2026-07-29T00:00:00Z",
+  "expiresAt": "2026-10-01T00:00:00Z",
+  "artifacts": [
+    {
+      "pioEnv": "tbeam-s3-core",
+      "hwModel": 12,
+      "architecture": "esp32-s3",
+      "version": "2.8.0.b00d76f",
+      "format": "bin",
+      "url": "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/<40-hex-commit>/event/...",
+      "sha256": "<64 lowercase hex characters>",
+      "byteCount": 2383792,
+      "minimumSourceVersion": "2.7.26",
+      "partitionRole": "app0",
+      "partitionScheme": "8MB",
+      "dfuProtocol": null,
+      "minimumBootloaderVersion": null
+    }
+  ],
+  "standardArtifacts": []
+}
+```
+
+`issuedAt` and `expiresAt` use UTC ISO-8601 timestamps with whole-second
+precision (`yyyy-MM-dd'T'HH:mm:ss'Z'`). `releaseId` and `keyId` are stable,
+bounded identifiers; they are not URLs or user-facing labels.
+
+`artifacts` installs the event edition. `standardArtifacts` provides the
+explicit return path to ordinary Meshtastic firmware. A production contract
+must contain both sets; a client must not infer the return artifact by editing
+an event URL or selecting whatever release happens to be latest.
+
+Selection is exact on `pioEnv`, `hwModel`, and `architecture`, with exactly one
+matching artifact. The client also enforces `minimumSourceVersion` and
+architecture-specific compatibility:
+
+- ESP32 artifacts are bare application `.bin` payloads for `app0`, never
+  factory, merged, filesystem, or OTA-loader images. Their partition scheme
+  must exactly match the connected target.
+- nRF52 artifacts are target-specific Nordic DFU OTA ZIPs. The contract names
+  the DFU protocol and minimum compatible bootloader. A client that cannot
+  establish the installed bootloader's compatibility must not offer in-app
+  DFU.
+- Unsupported architectures and devices without a proven app OTA path use the
+  web flasher.
+
+Artifact URLs are HTTPS, use an approved project origin, and identify immutable
+content. For `raw.githubusercontent.com`, the revision path component is a
+40-hex commit SHA. Clients reject redirects, enforce the signed byte count while
+downloading, then verify both byte count and SHA-256 before opening the existing
+OTA/DFU flow. Any failure falls back to the web flasher without writing bytes to
+the device.
+
+Signing keys are release infrastructure. Private keys live only in deployment
+secrets; public keys ship in clients. Rotation adds a new `keyId` and public key
+to clients before the API begins signing with it. Revocation requires removing
+the affected contract and shipping a client update when the trust key itself is
+compromised.
+
 ### Manifest shape
 
 ```jsonc
@@ -226,12 +323,35 @@ Fall back to the device zone only when `timeZone` is absent or unparseable, and 
 
 Drive this from the metadata date, not from a stored "event is over" bit: the prompt then appears whenever an ended-event device connects and disappears on its own once the device is re-flashed.
 
+## Behavior 5: Event Firmware Installation
+
+An event info or firmware-updates screen may offer a convenient install action,
+but only when the signed contract above authorizes one exact artifact for the
+connected device. Display metadata alone never enables the action.
+
+Before installation the client:
+
+1. Confirms the same device is still connected.
+2. Fetches and verifies the edition's signed contract.
+3. Selects one exact target and validates source-version and OTA compatibility.
+4. Downloads with a signed size ceiling and verifies SHA-256.
+5. Hands the local verified file to the platform's existing OTA/DFU flow.
+
+If any step is unavailable or fails, the primary action opens
+`https://flasher.meshtastic.org`. After the event, a compatible device running
+the event edition uses `standardArtifacts` through the same process. Clients
+must label this as a firmware rewrite, keep their existing OTA safety UI, and
+must not imply that background execution can keep a BLE/Wi-Fi transfer alive.
+
 ## Adding a New Event
 
 For an event whose enum value already exists, no client code changes are needed:
 
 1. Add an entry to `data/eventFirmware.json` in `meshtastic/api`.
 2. Add `static/eventFirmware/<slug>.png` and point `iconUrl` at it.
+3. To enable in-app OTA, add a reviewed entry to
+   `data/eventFirmwareOTA.json` with immutable per-target event and standard
+   artifacts, then configure the API's release signing key.
 
 Land both **well before the event** so online clients have refreshed their cache by the time attendees arrive. Per the caching table above, users who have been offline since install will not see the event until their client next reaches the network — bundling the icon and shipping the manifest snapshot in a client release is what covers them.
 
@@ -242,7 +362,7 @@ A new enum value requires a proto change coordinated via the `meshtastic/protobu
 | Platform | Branding | Theme | Notifications | Post-event | Notes |
 |---|---|---|---|---|---|
 | Android | ✅ | ✅ | ✅ | ✅ | Fonts Google-flavor only; no URL scheme allowlist; edition lookup is a one-shot, so a cache refresh needs a reconnect |
-| Apple | — | — | — | — | Not yet implemented |
+| Apple | PR | PR | PR | PR | Signed event OTA contract and installer are in draft; hardware event install remains untested |
 | Web | — | — | — | — | Not yet implemented |
 
 ## Sub-tasks
@@ -253,3 +373,5 @@ A new enum value requires a proto change coordinated via the `meshtastic/protobu
 - [ ] Resolve the two notification divergences above and align all platforms.
 - [ ] Enforce the URL scheme allowlist on link and icon fetches (Android does not today).
 - [ ] Make the edition lookup observable so a manifest refresh re-evaluates active branding without a reconnect (Android).
+- [ ] Provision and document the production event-firmware signing key and rotation process.
+- [ ] Hardware-validate each artifact target before adding it to a signed OTA contract.

--- a/.github/features/firmware-edition-event-behavior.md
+++ b/.github/features/firmware-edition-event-behavior.md
@@ -104,6 +104,9 @@ Clients ship the trusted public key keyed by `keyId`. A key delivered by this
 endpoint, the display manifest, or an artifact host is not a trust root.
 Unknown keys, malformed base64, invalid signatures, expired contracts, and
 unsupported schema versions make in-app installation unavailable.
+After signature verification, the client requires `payload.edition` to exactly
+match the requested `{EDITION}`. Contract caches are keyed by edition; a valid
+contract for one edition must never satisfy a request for another.
 
 The schema-1 contract is scoped to one event release:
 
@@ -132,7 +135,23 @@ The schema-1 contract is scoped to one event release:
       "minimumBootloaderVersion": null
     }
   ],
-  "standardArtifacts": []
+  "standardArtifacts": [
+    {
+      "pioEnv": "tbeam-s3-core",
+      "hwModel": 12,
+      "architecture": "esp32-s3",
+      "version": "2.7.26.54e0d8d",
+      "format": "bin",
+      "url": "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/<40-hex-commit>/firmware-2.7.26.54e0d8d/firmware-tbeam-s3-core-2.7.26.54e0d8d.bin",
+      "sha256": "<64 lowercase hex characters>",
+      "byteCount": 2213168,
+      "minimumSourceVersion": "2.7.26",
+      "partitionRole": "app0",
+      "partitionScheme": "8MB",
+      "dfuProtocol": null,
+      "minimumBootloaderVersion": null
+    }
+  ]
 }
 ```
 
@@ -149,13 +168,26 @@ Selection is exact on `pioEnv`, `hwModel`, and `architecture`, with exactly one
 matching artifact. The client also enforces `minimumSourceVersion` and
 architecture-specific compatibility:
 
+Signed versions use `MAJOR.MINOR.PATCH` or
+`MAJOR.MINOR.PATCH.SOURCE`, where the first three components are non-negative
+decimal integers and `SOURCE` contains only ASCII letters, digits, `_`, or `-`.
+A connected device version may additionally begin with `v`. Clients remove
+that prefix, compare the three numeric components lexicographically, and ignore
+the source-reference suffix for minimum-version ordering. Short versions,
+extra suffix components, integer overflow, and every other grammar are
+unsupported and reject the artifact.
+
 - ESP32 artifacts are bare application `.bin` payloads for `app0`, never
   factory, merged, filesystem, or OTA-loader images. Their partition scheme
-  must exactly match the connected target.
+  must exactly match the connected target. `partitionRole` and
+  `partitionScheme` are required and non-null; missing, null, or unknown values
+  reject the artifact before compatibility checks.
 - nRF52 artifacts are target-specific Nordic DFU OTA ZIPs. The contract names
-  the DFU protocol and minimum compatible bootloader. A client that cannot
-  establish the installed bootloader's compatibility must not offer in-app
-  DFU.
+  the DFU protocol and minimum compatible bootloader. `dfuProtocol` and
+  `minimumBootloaderVersion` are required and non-null; missing, null, or
+  unknown values reject the artifact before compatibility checks. A client
+  that cannot establish the installed bootloader's compatibility must not
+  offer in-app DFU.
 - Unsupported architectures and devices without a proven app OTA path use the
   web flasher.
 
@@ -335,7 +367,10 @@ Before installation the client:
 2. Fetches and verifies the edition's signed contract.
 3. Selects one exact target and validates source-version and OTA compatibility.
 4. Downloads with a signed size ceiling and verifies SHA-256.
-5. Hands the local verified file to the platform's existing OTA/DFU flow.
+5. Re-checks that the same device is connected, rebuilds its target identity,
+   and repeats exact-target and compatibility selection. A disconnect or
+   identity change during download aborts the install.
+6. Hands the local verified file to the platform's existing OTA/DFU flow.
 
 If any step is unavailable or fails, the primary action opens
 `https://flasher.meshtastic.org`. After the event, a compatible device running
@@ -351,7 +386,10 @@ For an event whose enum value already exists, no client code changes are needed:
 2. Add `static/eventFirmware/<slug>.png` and point `iconUrl` at it.
 3. To enable in-app OTA, add a reviewed entry to
    `data/eventFirmwareOTA.json` with immutable per-target event and standard
-   artifacts, then configure the API's release signing key.
+   artifacts, then configure the API's release signing key. The signing
+   `keyId` and public key must already be trusted by released clients. If they
+   are not, first ship a client release containing the public key and wait for
+   that release to reach users before publishing or enabling the OTA contract.
 
 Land both **well before the event** so online clients have refreshed their cache by the time attendees arrive. Per the caching table above, users who have been offline since install will not see the event until their client next reaches the network — bundling the icon and shipping the manifest snapshot in a client release is what covers them.
 


### PR DESCRIPTION
## Status

> [!WARNING]
> This contract is currently untested with a physical event-firmware OTA round trip. It is a draft for cross-platform, security, and release-infrastructure review.

## Summary

- Separates executable firmware authorization from the display-oriented event manifest.
- Defines an Ed25519-signed schema-v1 contract with exact device targeting, immutable artifact URLs, SHA-256, byte counts, source-version floors, and explicit return-to-standard artifacts.
- Defines ESP32 application-partition and nRF bootloader compatibility gates.
- Requires clients to fall back to `flasher.meshtastic.org` whenever compatibility or trust cannot be proven.
- Documents signing-key rotation, revocation, event setup, and the Apple draft implementation status.

## Why

The existing event manifest can describe branding and link to a firmware bundle, but it cannot safely authorize an app to write executable bytes. All clients need one shared contract for release identity, trust, exact-target selection, integrity verification, and returning a node to standard firmware.

## Validation

- `git diff --check`
- Reviewed against the current API event manifest and Apple draft installer behavior.
- Physical event OTA validation is still pending.

## Dependencies

- API implementation: meshtastic/api#110
- Apple draft: meshtastic/Meshtastic-Apple#2223

## Deployment Notes

The contract must not be activated until a project-owned Ed25519 release key is provisioned, its public key is shipped in clients, and every listed artifact has completed the hardware validation matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added requirements for secure event firmware installation, including signed, edition-specific contracts and device compatibility checks.
  * Documented HTTPS, approved artifact sources, redirect, size, checksum, and signature validation.
  * Added a final device-connection and compatibility check before installation, with fallback to the web flasher when validation fails.
  * Expanded event setup guidance for immutable firmware artifacts and trusted signing keys.
  * Updated Apple platform status and added signing-key rotation and hardware-validation tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->