### PR TITLE
docs: add writing style guide for issues, PRs, and commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Writing style
+
+This applies to everyone writing in this repo, human or agent: issues, pull requests, commit messages, and the docs under `standards/` and `styleguide/`.
+
+Keep it short and plain. Say what the problem is and what changed, in ordinary words. No invented jargon, no dramatized debugging stories, no bold-lead bullet lists that read like marketing. If there's nothing worth saying, say nothing.
+
+## Markdown
+
+Use American spelling: color, gray, meter, favorite.
+
+Don't hard-wrap. One line per paragraph and per bullet. Hard wrapping at 80 or 100 columns renders as ragged mid-sentence breaks inside list items on GitHub.
+
+Don't lead bullets with a bold label. `- **Thing** — explanation` reads like a marketing deck. Write prose, or use plain bullets where the content is genuinely a list.
+
+Prefer plain headings and prose over `> [!NOTE]` callouts, emoji in headings, and tables that hold one row.
+
+## Alignment issues
+
+Issues titled `[ALIGNMENT]: ...` follow a fixed shape. Match it instead of inventing your own:
+
+- `## Decision` — what clients must do, stated once, up front.
+- `## Context` — why, with links to the firmware, protocol, or client issues behind it.
+- `## Required Client Behavior` — numbered prose, one item per requirement.
+- `## Acceptance Criteria` — what has to be true for the work to be considered done.
+
+Add other sections only where the spec needs them, such as a per-client tracking checklist, firmware-owned behavior, or open questions. Issues #134 and #144 are good references.
+
+## Pull requests
+
+Use `## Summary`, `## What changed`, `## Testing`. Say plainly when a section doesn't apply — "not applicable, documentation only" beats inventing verification.
+
+## Commits
+
+A short subject saying what changed. Don't add `Co-Authored-By: Claude` or "Generated with Claude Code" trailers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Writing style
+
+This applies to everyone writing in this repo, human or agent: issues, pull requests, commit messages, and the docs under `standards/` and `styleguide/`.
+
+Keep it short and plain. Say what the problem is and what changed, in ordinary words. No invented jargon, no dramatized debugging stories, no bold-lead bullet lists that read like marketing. If there's nothing worth saying, say nothing.
+
+## Markdown
+
+Use American spelling: color, gray, meter, favorite.
+
+Don't hard-wrap. One line per paragraph and per bullet. Hard wrapping at 80 or 100 columns renders as ragged mid-sentence breaks inside list items on GitHub.
+
+Don't lead bullets with a bold label. `- **Thing** — explanation` reads like a marketing deck. Write prose, or use plain bullets where the content is genuinely a list.
+
+Prefer plain headings and prose over `> [!NOTE]` callouts, emoji in headings, and tables that hold one row.
+
+## Alignment issues
+
+Issues titled `[ALIGNMENT]: ...` follow a fixed shape. Match it instead of inventing your own:
+
+- `## Decision` — what clients must do, stated once, up front.
+- `## Context` — why, with links to the firmware, protocol, or client issues behind it.
+- `## Required Client Behavior` — numbered prose, one item per requirement.
+- `## Acceptance Criteria` — what has to be true for the work to be considered done.
+
+Add other sections only where the spec needs them, such as a per-client tracking checklist, firmware-owned behavior, or open questions. Issues #134 and #144 are good references.
+
+## Pull requests
+
+Use `## Summary`, `## What changed`, `## Testing`. Say plainly when a section doesn't apply — "not applicable, documentation only" beats inventing verification.
+
+## Commits
+
+A short subject saying what changed. Don't add `Co-Authored-By: Claude` or "Generated with Claude Code" trailers.


### PR DESCRIPTION
## Summary

There's no written style guide in this repo, so issues and PRs drift between plain prose and heavy formatting — callouts, emoji headings, bold-lead bullets. This writes down what we already do in the issues that read well.

## What changed

Adds `CLAUDE.md` and `AGENTS.md`. They're short: keep writing plain, use American spelling, don't hard-wrap markdown, don't lead bullets with bold labels. It also records the `[ALIGNMENT]:` issue structure (Decision / Context / Required Client Behavior / Acceptance Criteria) since that's repo-specific and easy to get wrong, and the Summary / What changed / Testing PR format.

The two files are intentionally identical copies, not a file and a pointer to it. `CLAUDE.md` is what Claude Code reads; `AGENTS.md` is the vendor-neutral name other agent tooling looks for. Please edit both together rather than deleting one.

## Testing

Not applicable, documentation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor writing guidelines covering prose style, Markdown formatting, issue structure, pull request sections, and commit message conventions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->