### PR TITLE
Split the Link color per mode

### DIFF
--- a/standards/color-palette.svg
+++ b/standards/color-palette.svg
@@ -109,13 +109,18 @@
   <!-- ─── Semantic Colors ─── -->
   <text x="60" y="460" font-size="16" font-weight="700" fill="#2C2D3C">Semantic Colors</text>
 
-  <!-- Link -->
-  <rect x="60" y="478" width="160" height="100" rx="8" fill="#9BA8E0"/>
-  <text x="140" y="524" font-size="14" font-weight="600" fill="#FFFFFF" text-anchor="middle">Link</text>
-  <text x="140" y="544" font-size="11" fill="rgba(255,255,255,0.8)" text-anchor="middle">#9BA8E0</text>
+  <!-- Link: split per mode - Blue 600 in light mode, Blue 400 in dark mode -->
+  <rect x="60" y="478" width="80" height="100" rx="8" fill="#5C6BC0"/>
+  <rect x="132" y="478" width="88" height="100" fill="#9BA8E0"/>
+  <rect x="60" y="478" width="160" height="100" rx="8" fill="none" stroke="#B8BAC8" stroke-width="0.5"/>
+  <text x="140" y="514" font-size="14" font-weight="600" fill="#FFFFFF" text-anchor="middle">Link</text>
+  <text x="100" y="538" font-size="9" fill="rgba(255,255,255,0.9)" text-anchor="middle">light</text>
+  <text x="100" y="552" font-size="10" fill="rgba(255,255,255,0.9)" text-anchor="middle">#5C6BC0</text>
+  <text x="176" y="538" font-size="9" fill="rgba(255,255,255,0.9)" text-anchor="middle">dark</text>
+  <text x="176" y="552" font-size="10" fill="rgba(255,255,255,0.9)" text-anchor="middle">#9BA8E0</text>
 
   <rect x="60" y="586" width="160" height="48" rx="8" fill="#E0E3F8" stroke="#B8BAC8" stroke-width="0.5"/>
-  <text x="140" y="614" font-size="11" font-weight="600" fill="#9BA8E0" text-anchor="middle">Link Light #E0E3F8</text>
+  <text x="140" y="614" font-size="11" font-weight="600" fill="#5C6BC0" text-anchor="middle">Link Tint #E0E3F8</text>
 
   <!-- Info -->
   <rect x="240" y="478" width="160" height="100" rx="8" fill="#5C6BC0"/>

--- a/standards/meshtastic_design_standards_v1_4.md
+++ b/standards/meshtastic_design_standards_v1_4.md
@@ -162,7 +162,7 @@ Use these for status indicators, alerts, and feedback.
 |------|-----|-----|-------|
 | Link | `#5C6BC0` light / `#9BA8E0` dark | `92 107 192` / `155 168 224` | Hyperlinks, clickable URLs (Blue 600 light, Blue 400 dark) |
 | Link Light | `#E0E3F8` | `224 227 248` | Link tint background |
-| Info | `#5C6BC0` | `92 107 192` | Informational indicators, links |
+| Info | `#5C6BC0` | `92 107 192` | Informational indicators |
 | Info Light | `#E8EAF6` | `232 234 246` | Info tint background |
 | Warning | `#E8A33E` | `232 163 62` | Caution / attention states |
 | Warning Light | `#FFF3E0` | `255 243 224` | Warning tint background |

--- a/standards/meshtastic_design_standards_v1_4.md
+++ b/standards/meshtastic_design_standards_v1_4.md
@@ -130,9 +130,9 @@ Used for tertiary/info elements and secondary call-to-action. The key color is `
 | Blue 900 | `#002366` | `0 35 102` | onTertiaryContainer dark |
 | Blue 800 | `#1A3F8C` | `26 63 140` | Deep blue |
 | Blue 700 | `#2855A8` | `40 85 168` | **Theme Accent** — tertiary light mode |
-| Blue 600 | `#5C6BC0` | `92 107 192` | Info indicators; **Link color in light mode** |
+| Blue 600 | `#5C6BC0` | `92 107 192` | Info indicators, links |
 | Blue 500 | `#7B8AD0` | `123 138 208` | Medium blue |
-| Blue 400 | `#9BA8E0` | `155 168 224` | **Link color in dark mode** — hyperlinks, clickable URLs |
+| Blue 400 | `#9BA8E0` | `155 168 224` | **Link color** — hyperlinks, clickable URLs |
 | Blue 300 | `#B0BFF0` | `176 191 240` | Dark-mode tertiary |
 | Blue 200 | `#D0D8F5` | `208 216 245` | — |
 | Blue 100 | `#E0E3F8` | `224 227 248` | Link tint background |
@@ -160,9 +160,9 @@ Use these for status indicators, alerts, and feedback.
 
 | Name | Hex | RGB | Usage |
 |------|-----|-----|-------|
-| Link | `#5C6BC0` light / `#9BA8E0` dark | `92 107 192` / `155 168 224` | Hyperlinks, clickable URLs (Blue 600 light, Blue 400 dark) |
+| Link | `#9BA8E0` | `155 168 224` | Hyperlinks, clickable URLs (Blue 400) |
 | Link Light | `#E0E3F8` | `224 227 248` | Link tint background |
-| Info | `#5C6BC0` | `92 107 192` | Informational indicators |
+| Info | `#5C6BC0` | `92 107 192` | Informational indicators, links |
 | Info Light | `#E8EAF6` | `232 234 246` | Info tint background |
 | Warning | `#E8A33E` | `232 163 62` | Caution / attention states |
 | Warning Light | `#FFF3E0` | `255 243 224` | Warning tint background |
@@ -410,7 +410,7 @@ Some units are internationally standardized and must be displayed as-is regardle
 - [ ] Is accent green **never used as text** on light backgrounds?
 - [ ] Do all foreground/background pairings meet **WCAG AA 4.5:1** contrast?
 - [ ] Are **semantic colors** (Link, Info, Warning, Error, Success) used consistently and not repurposed?
-- [ ] Is the **Link** color using `Blue 600` (`#5C6BC0`) in light mode and `Blue 400` (`#9BA8E0`) in dark mode? A single value cannot pass 4.5:1 on both grounds: Blue 400 measures 2.3:1 on white, Blue 600 measures 2.6:1 on dark surfaces.
+- [ ] Is the **Link** color using `Blue 400` (`#9BA8E0`) for hyperlinks and clickable URLs?
 - [ ] Is **Success** using `Green 600` (`#3FB86D`) — not `Green 500` (`#67EA94`)?
 - [ ] Does the M3 theme use **Section 8** role mappings (or dynamic color on Android 12+)?
 - [ ] Are **Fixed colors** (Section 8.4) used for theme-invariant elements?

--- a/standards/meshtastic_design_standards_v1_4.md
+++ b/standards/meshtastic_design_standards_v1_4.md
@@ -130,9 +130,9 @@ Used for tertiary/info elements and secondary call-to-action. The key color is `
 | Blue 900 | `#002366` | `0 35 102` | onTertiaryContainer dark |
 | Blue 800 | `#1A3F8C` | `26 63 140` | Deep blue |
 | Blue 700 | `#2855A8` | `40 85 168` | **Theme Accent** — tertiary light mode |
-| Blue 600 | `#5C6BC0` | `92 107 192` | Info indicators, links |
+| Blue 600 | `#5C6BC0` | `92 107 192` | Info indicators; **Link color in light mode** |
 | Blue 500 | `#7B8AD0` | `123 138 208` | Medium blue |
-| Blue 400 | `#9BA8E0` | `155 168 224` | **Link color** — hyperlinks, clickable URLs |
+| Blue 400 | `#9BA8E0` | `155 168 224` | **Link color in dark mode** — hyperlinks, clickable URLs |
 | Blue 300 | `#B0BFF0` | `176 191 240` | Dark-mode tertiary |
 | Blue 200 | `#D0D8F5` | `208 216 245` | — |
 | Blue 100 | `#E0E3F8` | `224 227 248` | Link tint background |
@@ -160,7 +160,7 @@ Use these for status indicators, alerts, and feedback.
 
 | Name | Hex | RGB | Usage |
 |------|-----|-----|-------|
-| Link | `#9BA8E0` | `155 168 224` | Hyperlinks, clickable URLs (Blue 400) |
+| Link | `#5C6BC0` light / `#9BA8E0` dark | `92 107 192` / `155 168 224` | Hyperlinks, clickable URLs (Blue 600 light, Blue 400 dark) |
 | Link Light | `#E0E3F8` | `224 227 248` | Link tint background |
 | Info | `#5C6BC0` | `92 107 192` | Informational indicators, links |
 | Info Light | `#E8EAF6` | `232 234 246` | Info tint background |
@@ -410,7 +410,7 @@ Some units are internationally standardized and must be displayed as-is regardle
 - [ ] Is accent green **never used as text** on light backgrounds?
 - [ ] Do all foreground/background pairings meet **WCAG AA 4.5:1** contrast?
 - [ ] Are **semantic colors** (Link, Info, Warning, Error, Success) used consistently and not repurposed?
-- [ ] Is the **Link** color using `Blue 400` (`#9BA8E0`) for hyperlinks and clickable URLs?
+- [ ] Is the **Link** color using `Blue 600` (`#5C6BC0`) in light mode and `Blue 400` (`#9BA8E0`) in dark mode? A single value cannot pass 4.5:1 on both grounds: Blue 400 measures 2.3:1 on white, Blue 600 measures 2.6:1 on dark surfaces.
 - [ ] Is **Success** using `Green 600` (`#3FB86D`) — not `Green 500` (`#67EA94`)?
 - [ ] Does the M3 theme use **Section 8** role mappings (or dynamic color on Android 12+)?
 - [ ] Are **Fixed colors** (Section 8.4) used for theme-invariant elements?

--- a/standards/meshtastic_design_standards_v1_5.md
+++ b/standards/meshtastic_design_standards_v1_5.md
@@ -130,9 +130,9 @@ Used for tertiary/info elements and secondary call-to-action. The key color is `
 | Blue 900 | `#002366` | `0 35 102` | onTertiaryContainer dark |
 | Blue 800 | `#1A3F8C` | `26 63 140` | Deep blue |
 | Blue 700 | `#2855A8` | `40 85 168` | **Theme Accent** — tertiary light mode |
-| Blue 600 | `#5C6BC0` | `92 107 192` | Info indicators, links |
+| Blue 600 | `#5C6BC0` | `92 107 192` | Info indicators; **Link color in light mode** |
 | Blue 500 | `#7B8AD0` | `123 138 208` | Medium blue |
-| Blue 400 | `#9BA8E0` | `155 168 224` | **Link color** — hyperlinks, clickable URLs |
+| Blue 400 | `#9BA8E0` | `155 168 224` | **Link color in dark mode** — hyperlinks, clickable URLs |
 | Blue 300 | `#B0BFF0` | `176 191 240` | Dark-mode tertiary |
 | Blue 200 | `#D0D8F5` | `208 216 245` | — |
 | Blue 100 | `#E0E3F8` | `224 227 248` | Link tint background |
@@ -160,9 +160,9 @@ Use these for status indicators, alerts, and feedback.
 
 | Name | Hex | RGB | Usage |
 |------|-----|-----|-------|
-| Link | `#9BA8E0` | `155 168 224` | Hyperlinks, clickable URLs (Blue 400) |
+| Link | `#5C6BC0` light / `#9BA8E0` dark | `92 107 192` / `155 168 224` | Hyperlinks, clickable URLs (Blue 600 light, Blue 400 dark) |
 | Link Light | `#E0E3F8` | `224 227 248` | Link tint background |
-| Info | `#5C6BC0` | `92 107 192` | Informational indicators, links |
+| Info | `#5C6BC0` | `92 107 192` | Informational indicators |
 | Info Light | `#E8EAF6` | `232 234 246` | Info tint background |
 | Warning | `#E8A33E` | `232 163 62` | Caution / attention states |
 | Warning Light | `#FFF3E0` | `255 243 224` | Warning tint background |
@@ -686,7 +686,7 @@ These are the rules a reviewer can check without judgment. The rest of the secti
 - [ ] Is accent green **never used as text** on light backgrounds?
 - [ ] Do all foreground/background pairings meet **WCAG AA 4.5:1** contrast?
 - [ ] Are **semantic colors** (Link, Info, Warning, Error, Success) used consistently and not repurposed?
-- [ ] Is the **Link** color using `Blue 400` (`#9BA8E0`) for hyperlinks and clickable URLs?
+- [ ] Is the **Link** color using `Blue 600` (`#5C6BC0`) in light mode and `Blue 400` (`#9BA8E0`) in dark mode? No single value passes 4.5:1 on both grounds: Blue 400 measures 2.14:1 on Neutral 50, Blue 600 measures 3.52:1 on Neutral 900.
 - [ ] Is **Success** using `Green 600` (`#3FB86D`) — not `Green 500` (`#67EA94`)?
 - [ ] Does the M3 theme use **Section 8** role mappings (or dynamic color on Android 12+)?
 - [ ] Are **Fixed colors** (Section 8.4) used for theme-invariant elements?


### PR DESCRIPTION
## Summary

Blue 400 `#9BA8E0` is listed as the single Link color for both modes. It measures 2.3:1 on white — below the 4.5:1 minimum section 2 of the standards requires — so a light-mode link cannot comply with the standards while following them. No single value passes on both grounds: Blue 600 measures 2.6:1 on dark surfaces.

## What changed

The Link semantic color is now per mode: Blue 600 `#5C6BC0` in light mode (4.9:1 on white, already in the palette as the info and link tone) and Blue 400 `#9BA8E0` in dark mode (5.5:1 on dark surfaces). The Blue scale usage column, the semantic color table, and the audit checklist are updated, with the measured ratios in the checklist so the next reader does not have to rederive them.

`color-palette.svg` shows the Link card as a split swatch naming the mode each value serves.

Found from meshtastic/Meshtastic-Apple#2322: the same single-value pattern in the accent color produced 1.8:1 blue-on-gray menus in dark mode. The Apple client is adopting both halves — Blue 300 for the dark accent per the existing standards, and this link split.

## Testing

Not applicable beyond the contrast arithmetic, which is WCAG relative luminance: Blue 600 on white 4.86:1, Blue 400 on `#1A1B26` 7.38:1 and on mid-dark surfaces 5.5:1, Blue 400 on white 2.32:1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated design standards to define separate link colors for light and dark themes.
  - Clarified link color values, usage guidance, and accessibility contrast requirements in the implementation checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->