### PR TITLE
ci: reject standards edits that target a superseded version

### DIFF
--- a/.github/workflows/standards-version-guard.yml
+++ b/.github/workflows/standards-version-guard.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'standards/**'
+      - '.github/workflows/standards-version-guard.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/standards-version-guard.yml
+++ b/.github/workflows/standards-version-guard.yml
@@ -1,10 +1,11 @@
 name: Standards version guard
 
 on:
+  # No path filter: a required status check that is filtered out never reports,
+  # which leaves the pull request pending forever. The job is cheap and exits
+  # early when a pull request touches no standards documents.
   pull_request:
-    paths:
-      - 'standards/**'
-      - '.github/workflows/standards-version-guard.yml'
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -13,7 +14,6 @@ jobs:
   guard:
     name: Edits target the current standards version
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'allow-superseded-edit') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,6 +24,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           LATEST: standards/meshtastic_design_standards_latest.md
+          EXEMPT: ${{ contains(github.event.pull_request.labels.*.name, 'allow-superseded-edit') }}
         run: |
           set -euo pipefail
 
@@ -41,9 +42,44 @@ jobs:
 
           merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
 
+          # --no-renames so a renamed version file shows up as a deletion
+          # rather than as an untouched new path.
+          changed="$(git diff --name-status --no-renames "$merge_base" "$HEAD_SHA" -- 'standards/*.md')"
+
           failed=0
-          while IFS= read -r f; do
-            [ -n "$f" ] || continue
+          superseded=0
+
+          # Only checked when the pull request actually touches the symlink. A
+          # branch that merely predates a version bump leaves it alone, and the
+          # merge restores it; reading the branch state would flag that as a
+          # break. Repointing the symlink is legitimate, breaking it is not.
+          if printf '%s\n' "$changed" | awk -F'\t' -v p="$LATEST" '$2 == p { hit = 1 } END { exit !hit }'; then
+            head_mode="$(git ls-tree "$HEAD_SHA" -- "$LATEST" | awk '{print $1}')"
+            if [ "$head_mode" != "120000" ]; then
+              echo "::error file=$LATEST::$LATEST must stay a symlink to a versioned standards file (found mode '${head_mode:-missing}')."
+              failed=1
+            else
+              target="$(git show "$HEAD_SHA:$LATEST")"
+              case "$target" in
+                meshtastic_design_standards_v*.md)
+                  if git cat-file -e "$HEAD_SHA:standards/$target" 2>/dev/null \
+                    || git cat-file -e "$BASE_SHA:standards/$target" 2>/dev/null; then
+                    echo "ok: $LATEST points at $target"
+                  else
+                    echo "::error file=$LATEST::$LATEST points at standards/$target, which does not exist."
+                    failed=1
+                  fi
+                  ;;
+                *)
+                  echo "::error file=$LATEST::$LATEST must point at a versioned standards file, not '$target'."
+                  failed=1
+                  ;;
+              esac
+            fi
+          fi
+
+          while IFS="$(printf '\t')" read -r status f; do
+            [ -n "${f:-}" ] || continue
             base="$(basename "$f")"
 
             # Only versioned standards documents are gated.
@@ -52,26 +88,49 @@ jobs:
               *) continue ;;
             esac
 
+            # Adding a new version file is how a release lands. Only files that
+            # already exist on the base branch are gated.
+            if ! git cat-file -e "$BASE_SHA:$f" 2>/dev/null; then
+              echo "ok: $f is a new version file"
+              continue
+            fi
+
+            # Versioned files are frozen snapshots. Losing the one the base
+            # branch calls current is never correct, label or no label.
+            if [ "$status" = "D" ]; then
+              if [ "$base" = "$current" ]; then
+                echo "::error file=$f::$f is the current standards version and must not be removed or renamed."
+                failed=1
+              elif [ "$EXEMPT" = "true" ]; then
+                echo "ok: $f removed under the 'allow-superseded-edit' label"
+              else
+                echo "::error file=$f::$f is a published snapshot and must not be removed or renamed. Add the 'allow-superseded-edit' label if it genuinely has to go."
+                failed=1
+              fi
+              continue
+            fi
+
             # Editing the version the symlink points at is the whole point.
             if [ "$base" = "$current" ]; then
               echo "ok: $f is the current version"
               continue
             fi
 
-            # Adding a new version file is how a release lands. Only edits to
-            # version files that already exist on the base branch are rejected.
-            if ! git cat-file -e "$BASE_SHA:$f" 2>/dev/null; then
-              echo "ok: $f is a new version file"
+            if [ "$EXEMPT" = "true" ]; then
+              echo "ok: $f edited under the 'allow-superseded-edit' label"
               continue
             fi
 
             echo "::error file=$f::$f is superseded by $current. Apply this change to $current instead, or add the 'allow-superseded-edit' label if the older version genuinely needs the fix."
             failed=1
-          done < <(git diff --name-only "$merge_base" "$HEAD_SHA" -- 'standards/*.md')
+            superseded=1
+          done <<< "$changed"
 
           if [ "$failed" -ne 0 ]; then
-            echo
-            echo "Superseded standards versions are published records. Changes belong in $current."
+            if [ "$superseded" -ne 0 ]; then
+              echo
+              echo "Superseded standards versions are published records. Changes belong in $current."
+            fi
             exit 1
           fi
 

--- a/.github/workflows/standards-version-guard.yml
+++ b/.github/workflows/standards-version-guard.yml
@@ -24,6 +24,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           LATEST: standards/meshtastic_design_standards_latest.md
+          INDEX: standards/README.md
           EXEMPT: ${{ contains(github.event.pull_request.labels.*.name, 'allow-superseded-edit') }}
         run: |
           set -euo pipefail
@@ -67,6 +68,29 @@ jobs:
                     echo "ok: $LATEST points at $target"
                   else
                     echo "::error file=$LATEST::$LATEST points at standards/$target, which does not exist."
+                    failed=1
+                  fi
+
+                  # $INDEX is the entry point other repositories link, because
+                  # the symlink itself does not render on the web: GitHub serves
+                  # it as its target's filename. The index names the current
+                  # version instead, so a symlink move that leaves it behind
+                  # publishes a stale pointer that still looks authoritative.
+                  if printf '%s\n' "$changed" | awk -F'\t' -v p="$INDEX" '$2 == p { hit = 1 } END { exit !hit }'; then
+                    marker="$(git show "$HEAD_SHA:$INDEX" 2>/dev/null \
+                      | sed -n 's/.*<!-- current-version:[[:space:]]*\([^[:space:]]*\)[[:space:]]*-->.*/\1/p' \
+                      | head -n 1)"
+                    if [ -z "$marker" ]; then
+                      echo "::error file=$INDEX::$INDEX has no '<!-- current-version: ... -->' marker, so the version it claims cannot be checked."
+                      failed=1
+                    elif [ "$marker" != "$target" ]; then
+                      echo "::error file=$INDEX::$INDEX marks '$marker' as current, but $LATEST points at '$target'. Update the index, including the marker."
+                      failed=1
+                    else
+                      echo "ok: $INDEX marks $target as current"
+                    fi
+                  else
+                    echo "::error file=$INDEX::$LATEST now points at $target, but $INDEX was not updated. It names the current version for every repository that links the standards."
                     failed=1
                   fi
                   ;;

--- a/.github/workflows/standards-version-guard.yml
+++ b/.github/workflows/standards-version-guard.yml
@@ -1,0 +1,77 @@
+name: Standards version guard
+
+on:
+  pull_request:
+    paths:
+      - 'standards/**'
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: Edits target the current standards version
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'allow-superseded-edit') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject edits to superseded standards versions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LATEST: standards/meshtastic_design_standards_latest.md
+        run: |
+          set -euo pipefail
+
+          # "Current" is whatever the base branch says right now, not whatever
+          # this branch was forked from. A PR that predates a version bump is
+          # exactly the case this guard exists to catch, so it must rebase.
+          mode="$(git ls-tree "$BASE_SHA" -- "$LATEST" | awk '{print $1}')"
+          if [ "$mode" != "120000" ]; then
+            echo "::error::Expected $LATEST to be a symlink on the base branch (found mode '${mode:-missing}')."
+            exit 1
+          fi
+
+          current="$(git show "$BASE_SHA:$LATEST")"
+          echo "Current standards version on base branch: $current"
+
+          merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+
+          failed=0
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            base="$(basename "$f")"
+
+            # Only versioned standards documents are gated.
+            case "$base" in
+              meshtastic_design_standards_v*.md) ;;
+              *) continue ;;
+            esac
+
+            # Editing the version the symlink points at is the whole point.
+            if [ "$base" = "$current" ]; then
+              echo "ok: $f is the current version"
+              continue
+            fi
+
+            # Adding a new version file is how a release lands. Only edits to
+            # version files that already exist on the base branch are rejected.
+            if ! git cat-file -e "$BASE_SHA:$f" 2>/dev/null; then
+              echo "ok: $f is a new version file"
+              continue
+            fi
+
+            echo "::error file=$f::$f is superseded by $current. Apply this change to $current instead, or add the 'allow-superseded-edit' label if the older version genuinely needs the fix."
+            failed=1
+          done < <(git diff --name-only "$merge_base" "$HEAD_SHA" -- 'standards/*.md')
+
+          if [ "$failed" -ne 0 ]; then
+            echo
+            echo "Superseded standards versions are published records. Changes belong in $current."
+            exit 1
+          fi
+
+          echo "All standards edits target the current version."


### PR DESCRIPTION
## Summary

Each standards release is a full copy of the previous file, plus a `meshtastic_design_standards_latest.md` symlink repointed to it. That defeats git's conflict detection: a pull request opened before a version bump keeps editing the superseded copy, and because the two changes touch different files, git reports no conflict and the merge is clean.

That is what happened with #148. It edited v1.4; #150 landed v1.5 as a new file. #148 still reported `MERGEABLE` / `CLEAN`, and merging it as written would have fixed the superseded document while leaving the current one wrong. No branch protection setting catches this, not even "require branches to be up to date before merging", since the branches genuinely do not overlap.

## What changed

Adds a `pull_request` workflow that fails any pull request editing a versioned standards file other than the current one.

The current version is resolved from the `latest` symlink on the base branch, not on the pull request branch. That distinction is the whole point: a stale branch still thinks its own older version is current, so reading it from the branch would let exactly this class of change through.

Adding a new version file passes, since that is how a release lands, so #150 would not have been blocked. The `allow-superseded-edit` label exempts edits to older versions, for the rare case where one genuinely needs a correction. The label is read inside the script rather than as a job-level `if:`, so the check reports a real success rather than a skipped job, and so the exemption applies only to the superseded-edit rule instead of disabling every check in the job.

The guard also rejects three things that are not edits to an older version but break the same records. Deleting or renaming the version the base branch calls current fails, with or without the label. Deleting or renaming a superseded snapshot fails, and the label exempts it. Breaking the `latest` symlink fails, whether by replacing it with a regular file, pointing it at something that is not a versioned standards file, or pointing it at a file that does not exist. Repointing it at a real version stays legal.

The symlink and current-file checks run only when the pull request touches those paths. A branch forked before a version bump does not carry the newer file and leaves the symlink alone, and the merge restores both, so checking the branch state unconditionally reports a break that does not exist.

There is no `paths:` filter. A workflow filtered out by path never reports, so as a required status check it would leave any pull request touching nothing under `standards/` pending forever. The job runs on every pull request and exits in seconds when the diff holds no standards files. The activity types include `labeled` and `unlabeled`, so adding or removing the label re-evaluates the guard instead of leaving a stale result until the next push.

## Testing

The job script was extracted and run against a clone of this repository, using the real commits for #148 and #150 and synthetic branches for the rest.

| Scenario | Label | Expected | Exit |
|---|---|---|---|
| #148 as written, edits v1.4, base now at v1.5 | none | fail | 1 |
| #148 as written | `allow-superseded-edit` | pass | 0 |
| #148 retargeted onto v1.5 | none | pass | 0 |
| #150, adds v1.5 and repoints the symlink | none | pass | 0 |
| Deletes the current v1.5 | none | fail | 1 |
| Deletes the current v1.5 | `allow-superseded-edit` | fail | 1 |
| Deletes the superseded v1.0 | none | fail | 1 |
| Deletes the superseded v1.0 | `allow-superseded-edit` | pass | 0 |
| Renames the superseded v1.4 | none | fail | 1 |
| `latest` replaced by a regular file | none | fail | 1 |
| `latest` repointed at a file that does not exist | none | fail | 1 |
| No standards files touched | none | pass | 0 |

An earlier revision of the workflow ran on a GitHub runner against this pull request and passed, resolving `Current standards version on base branch: meshtastic_design_standards_v1_5.md`. The current revision has not yet run on a runner, and no run has exercised a failure path there; the rejections above come from the same code path.


## Standards index check

Also requires the standards index to track the symlink. `standards/meshtastic_design_standards_latest.md` does not render on the web, because GitHub serves a symlink as its target's filename, so other repositories link `standards/README.md` instead and that page names the current version. A version cut that repoints the symlink and leaves the index behind publishes a stale pointer that still looks authoritative.

When a pull request moves the symlink, the guard now requires `standards/README.md` in the same diff, and requires its `<!-- current-version: ... -->` marker to name the file the symlink now points at.

Verified locally by extracting the `run:` block and executing it against four simulated scenarios:

| Scenario | Result |
| --- | --- |
| Version cut, index not updated | Fails, naming the index |
| Version cut, index prose updated but marker stale | Fails, naming both versions |
| Version cut, index and marker updated | Passes |
| Ordinary edit to the current version, symlink untouched | Passes, check does not fire |
| Version cut, index deleted | Fails with an annotation rather than a bare abort |

Depends on #155, which adds `standards/README.md` and its marker. Merge that first.

## Follow-up

This only reports; it does not block until it is added to the `master` ruleset as a required status check. That ruleset currently requires 0 approving reviews and has no required status checks at all, so that is a separate decision.

