### PR TITLE
Add a standards index so links stop going stale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,11 @@ Use `## Summary`, `## What changed`, `## Testing`. Say plainly when a section do
 ## Commits
 
 A short subject saying what changed. Don't add `Co-Authored-By: Claude` or "Generated with Claude Code" trailers.
+
+## Cutting a standards version
+
+`standards/README.md` is the entry point every other repository links to, and it names the current version, so it has to change whenever that version does. Follow the steps under "Cutting a version" on that page: add the new version file, repoint the `meshtastic_design_standards_latest.md` symlink, then update the version named at the top of the index and the row in its table.
+
+Do all of it in the commit that adds the version. An index naming a version that is no longer current is worse than no index, because it looks authoritative.
+
+Don't link `meshtastic_design_standards_latest.md` from anywhere on the web. GitHub serves a symlink as its target's filename, so the blob and raw views return the file name rather than the standards. Link `standards/` instead.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Secondary/Background/Accent color:
 
 ### Extended Color Palette
 
-The complete extended palette — including Neutral Scale, Green Scale, Semantic Colors, and Theme Colors — is documented visually in the [Color Palette SVG](standards/color-palette.svg) and defined in the [Meshtastic Client Design Standards](standards/meshtastic_design_standards_latest.md).
+The complete extended palette — including Neutral Scale, Green Scale, Semantic Colors, and Theme Colors — is documented visually in the [Color Palette SVG](standards/color-palette.svg) and defined in the [Meshtastic Client Design Standards](standards/).
 
 > **Accessibility note:** All foreground/background pairings meet WCAG AA contrast (4.5:1 minimum). Never use `#67EA94` for text on light backgrounds — use `Green 600` (`#3FB86D`) or `Green 700` (`#2D8F52`) instead.
 
@@ -88,15 +88,26 @@ To regenerate the action bar icons use the Image Asset tool to import logo/svg/M
 
 ## Design Standards
 
-All UI must comply with the [Meshtastic Client Design Standards](https://raw.githubusercontent.com/meshtastic/design/refs/heads/master/standards/meshtastic_design_standards_latest.md). Fetch and review this document before making any UI changes.
+All UI must comply with the [Meshtastic Client Design Standards](standards/). Review the current version before making any UI changes.
 
-This ensures that Copilot will fetch and reference the latest design standards whenever it assists with UI-related code, helping maintain cross-platform consistency for colors, typography, node identity, accessibility, and theming.
+The [standards directory](https://github.com/meshtastic/design/tree/master/standards) always names the current version, so a link to it never goes stale. Don't link the `meshtastic_design_standards_latest.md` symlink from the web: GitHub serves it as its target's filename rather than as the document.
 
 ## Using Design Standards with GitHub Copilot
 
-If you are developing a Meshtastic client, you can configure GitHub Copilot to automatically enforce the [Meshtastic Client Design Standards](standards/meshtastic_design_standards_latest.md) when making UI changes.
+If you are developing a Meshtastic client, you can configure GitHub Copilot to automatically enforce the [Meshtastic Client Design Standards](standards/) when making UI changes.
 
 Add the following section to your repository's `.github/copilot-instructions.md` file (create the file if it doesn't exist):
+
+```markdown
+## Meshtastic design standards
+
+All UI work in this repository follows the Meshtastic Client Design Standards:
+https://github.com/meshtastic/design/tree/master/standards
+
+That page names the current version and links it. Read the current version
+before changing UI, and apply sections 1 through 10 to client UI and section 11
+to documentation and in-product text.
+```
 
 ## Stats
 

--- a/standards/README.md
+++ b/standards/README.md
@@ -1,0 +1,49 @@
+# Meshtastic Client Design Standards
+
+The current version is v1.5: [meshtastic_design_standards_v1_5.md](meshtastic_design_standards_v1_5.md).
+
+<!-- current-version: meshtastic_design_standards_v1_5.md -->
+<!-- Keep this marker and the line above it pointing at the same file as the
+     meshtastic_design_standards_latest.md symlink. CI compares them. -->
+
+It governs client UI across Android, Apple, Web and desktop, and section 11 governs the documentation site, the written material in this repository, and the text inside the clients.
+
+## Linking to the standards
+
+Link to this directory. `https://github.com/meshtastic/design/tree/master/standards` renders this page, always names the current version, and never needs updating in the repository doing the linking.
+
+Don't link `meshtastic_design_standards_latest.md` from the web. It is a symlink, and GitHub serves a symlink as its target's filename rather than as the document it points at, so both the blob view and `raw.githubusercontent.com` return 35 bytes of text and no standards. The symlink works normally on a filesystem, so a local clone can still read it:
+
+```shell
+cat standards/meshtastic_design_standards_latest.md
+```
+
+A tool that needs the document over HTTP can use the REST contents API, which does resolve the symlink:
+
+```shell
+gh api repos/meshtastic/design/contents/standards/meshtastic_design_standards_latest.md \
+  -H "Accept: application/vnd.github.raw"
+```
+
+## Versions
+
+| Version | File | Status |
+| --- | --- | --- |
+| v1.5 | [meshtastic_design_standards_v1_5.md](meshtastic_design_standards_v1_5.md) | Current |
+| v1.4 | [meshtastic_design_standards_v1_4.md](meshtastic_design_standards_v1_4.md) | Superseded |
+| v1.3 | [meshtastic_design_standards_v1_3.md](meshtastic_design_standards_v1_3.md) | Superseded |
+| v1.2 | [meshtastic_design_standards_v1_2.md](meshtastic_design_standards_v1_2.md) | Superseded |
+| v1.0 | [meshtastic_design_standards_v1_0.md](meshtastic_design_standards_v1_0.md) | Superseded |
+
+Superseded versions are published records and are not edited. Changes belong in the current version.
+
+## Cutting a version
+
+Four edits, in one commit:
+
+1. Add the new version file.
+2. Repoint the `meshtastic_design_standards_latest.md` symlink at it.
+3. Change the version named at the top of this page, and the `current-version` marker beside it.
+4. Add a row to the table, and mark the previous version superseded.
+
+Steps three and four are the whole maintenance cost of this page, and they buy every other repository never having to change a link.


### PR DESCRIPTION
## Summary

`standards/meshtastic_design_standards_latest.md` is a symlink. GitHub serves a symlink as its target's filename rather than as the file it points at, so both the blob view and `raw.githubusercontent.com` return 35 bytes reading `meshtastic_design_standards_v1_5.md` and no standards at all. Every web link to it is broken, including the one in this README instructing GitHub Copilot to "fetch and review this document before making any UI changes."

Linking a versioned file instead renders correctly, but then every consumer repository needs an edit at each version cut, and a missed one points at superseded standards with no error.

A README in `standards/` fixes both. GitHub renders it at `https://github.com/meshtastic/design/tree/master/standards`, so consumers link that directory once, and cutting a version updates one file in this repository.

## What changed

Adds `standards/README.md`, which names the current version, links every version with its status, explains why not to link the symlink from the web, and gives the two forms that do resolve it: a local `cat`, and the REST contents API with a raw accept header.

Repoints the three `latest.md` links in the root README at `standards/`.

Adds a "Cutting a standards version" section to `CLAUDE.md`, so the index is updated in the same commit that cuts a version. The index is only correct if that happens, and an index naming a stale version looks authoritative while being wrong.

Supplies the `copilot-instructions.md` snippet the README's Copilot section promised. That section ended at "Add the following section" with no snippet following it, so anyone following the instructions had nothing to copy.

## Testing

Not applicable, documentation only. Verified the symlink behavior against the live repository before writing it up: the blob view and `raw.githubusercontent.com` both return the 35-byte target name, while `gh api` with `Accept: application/vnd.github.raw` returns the full 49,693-byte document. Confirmed no link to `latest.md` remains in the root README.
